### PR TITLE
chore: Attribute copyright to Geert Jan van Oldenborgh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 hep-packaging-coordination
+Copyright (c) 1990 Geert Jan van Oldenborgh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* Geert Jan van Oldenborgh produced the original unlicensed version of FF.