### PR TITLE
fix: Allow for longer paths for ffopen

### DIFF
--- a/src/ff/ffinit.f
+++ b/src/ff/ffinit.f
@@ -756,7 +756,7 @@
 	character*(*) name
 *
 	logical lopen
-	character*128 path,fullname
+	character*512 path,fullname
 *
 	include 'ff.h'
 *


### PR DESCRIPTION
* The ffopen subroutine path and fullname variables need to have enough characters to hold longer paths that can come up, such as the $PREFIX variable in conda-build builds, so extend the length to 512 (2^9) characters.