### PR TITLE
feat: Update to QCDLoop v1.981 FF

### DIFF
--- a/src/ff/ChangeLog
+++ b/src/ff/ChangeLog
@@ -1,0 +1,16 @@
+Fri Jul 24 2020  Keith Ellis <keith.ellis@durham.ac.uk>
+
+At the suggestion of jacek.m.holeczek@gmail.com
+	we have made two modifications to facilitate compilation with
+	modern fortran compilers, which do greater checks on array sizes.
+
+        * ffxd0p.f:
+	       removed calls to ffcxra and ffxtra with the penultimate argument ii=3
+	       (both of these routines have as their first executable statement
+	       "if ( ii .eq. 3 ) return", so this is clearly innocuous
+
+        * aaxex.f:
+	       for similar reasons changed the second argument of the call to mdxi
+	       call ffeji(cdxi,mdxi,ccxi,mcxi,cbxi,mbxi,caxi,maxi,
+	      +		cdxj,mdxj,ccxj,mcxj,cbxj,mbxj,caxj,maxj,level)
+               this routine is never called, so this is also innocuous

--- a/src/ff/Makefile
+++ b/src/ff/Makefile
@@ -1,4 +1,5 @@
-FFLAGS        = 
+FC            = gfortran
+FFLAGS        = -std=legacy
 
 LFLAGS	      = $(FFLAGS)
 
@@ -7,7 +8,7 @@ DEST	      = /usr/local/lib
 HDRS	      = aa.h \
 		ff.h
 
-LIBRARY	      = ff.a
+LIBRARY	      = libff.a
 
 MAKEFILE      = Makefile
 
@@ -162,7 +163,7 @@ test:		npointes
 		diff -w npointes.out npointes.sun
 
 npointes:	npointes.o $(LIBRARY)
-		f77 $(LFLAGS) -o npointes npointes.o $(LIBRARY)
+		$(FC) $(LFLAGS) -o npointes npointes.o $(LIBRARY)
 
 $(LIBRARY):	$(OBJS) $(AAOBJS)
 		ar cru $(LIBRARY) $(OBJS) $(AAOBJS)

--- a/src/ff/README
+++ b/src/ff/README
@@ -1,3 +1,5 @@
+8-sep-2003.  A special case in C11 was found to be wrongly coded (thanks Andre van Hameren).  In rare circumstances thtis would give the wrong value for C11.  New ffxc1.f
+
 1-sept-1996.  In spite of my new job at the KNMI, I still fully support 
 the FF library.
 

--- a/src/ff/aaxex.f
+++ b/src/ff/aaxex.f
@@ -215,7 +215,7 @@
 *
 *	convert ??xj to ??xi
 *
-	call ffeji(cdxi,mcxi,ccxi,mcxi,cbxi,mbxi,caxi,maxi,
+	call ffeji(cdxi,mdxi,ccxi,mcxi,cbxi,mbxi,caxi,maxi,
      +		cdxj,mdxj,ccxj,mcxj,cbxj,mbxj,caxj,maxj,level)
 *
 *	and call the real routine for the rest
@@ -460,8 +460,8 @@
 *
 *	copy FF structs to AA
 *
-	do i=16,35
-	    cexi(i) = ce3ijk(m2ijk(1,i),m2ijk(2,i),m2ijk(3,i))
+	do i=1,20
+	    cexi(i+15) = ce3ijk(m2ijk(1,i),m2ijk(2,i),m2ijk(3,i))
 	enddo
 	if ( atest ) then
 *

--- a/src/ff/ffcel5.f
+++ b/src/ff/ffcel5.f
@@ -410,7 +410,7 @@
 		    xmax = max(xmax,absc(piDpj(j,i)))
     1		continue
 		if ( xloss*absc(cnul) .gt. precx*xmax ) print *,
-     +			'ffcl4r: error: \sum p',i,'.p6-10 do not add ',
+     +			'ffcl4r: error: sum p',i,'.p6-10 do not add ',
      +			'up to 0: ',cnul,xmax
 		cnul = 0
 		xmax = 0
@@ -419,7 +419,7 @@
 		    xmax = max(xmax,absc(piDpj(j,i)))
     2		continue
 		if ( xloss*absc(cnul) .gt. precx*xmax ) print *,
-     +			'ffcl4r: error: \sum p',i,'.p11-15 do not add ',
+     +			'ffcl4r: error: sum p',i,'.p11-15 do not add ',
      +			'up to 0: ',cnul,xmax
 		do 3 j=6,10
 		    k = j+1
@@ -427,7 +427,7 @@
 		    cnul = piDpj(i,j) + piDpj(i,k) - piDpj(i,j+5)
 		    xmax = max(abs(piDpj(i,j)),abs(piDpj(i,k)))
 		    if ( xloss*absc(cnul) .gt. precx*xmax ) print *,
-     +			'ffcl4r: error: \sum p',i,'.p',j,k,j+5,' do ',
+     +			'ffcl4r: error: sum p',i,'.p',j,k,j+5,' do ',
      +			'not add up to 0: ',cnul,xmax
     3		continue
     4	    continue

--- a/src/ff/ffdel5.f
+++ b/src/ff/ffdel5.f
@@ -502,7 +502,7 @@
 		    xmax = max(xmax,abs(piDpj(j,i)))
     1		continue
 		if ( xloss*xnul .gt. precx*xmax ) print *,'ffdl4r: ',
-     +			'error: \sum p',i,'.p6-10 do not add up to 0: ',
+     +			'error: sum p',i,'.p6-10 do not add up to 0: ',
      +			xnul,xmax
 		xnul = 0
 		xmax = 0
@@ -511,7 +511,7 @@
 		    xmax = max(xmax,abs(piDpj(j,i)))
     2		continue
 		if ( xloss*xnul .gt. precx*xmax ) print *,'ffdl4r: ',
-     +			'error: \sum p',i,'.p11-15 do not add up to 0:',
+     +			'error: sum p',i,'.p11-15 do not add up to 0:',
      +			xnul,xmax
 *		do 3 j=6,10
 *		    k = j+1
@@ -519,7 +519,7 @@
 *		    xnul = piDpj(i,j) + piDpj(i,k) - piDpj(i,j+5)
 *		    xmax = max(abs(piDpj(i,j)),abs(piDpj(i,k)))
 *		    if ( xloss*xnul .gt. precx*xmax ) print *,'ffdl4r:',
-*     +			' error: \sum p',i,'.p',j,k,j+5,' do not add ',
+*     +			' error: sum p',i,'.p',j,k,j+5,' do not add ',
 *     +			'up to 0: ',xnul,xmax
 *    3		continue
     4	    continue

--- a/src/ff/ffinit.f
+++ b/src/ff/ffinit.f
@@ -321,7 +321,7 @@
 *	the debugging flags.
 *
 	lwrite = .FALSE.
-	ltest = .TRUE.
+	ltest = .FALSE.
 	lwarn = .TRUE.
 	ldc3c4 = .FALSE.
 	l4also = .FALSE.

--- a/src/ff/ffxc1.f
+++ b/src/ff/ffxc1.f
@@ -182,7 +182,7 @@
 	ms(4) = 2*mc0*abs(piDpj(1,5)*piDpj(4,5))
 	ms(5) = 2*mc0*abs(piDpj(1,4)*piDpj(5,5))
 *	exceptions
-	if ( xpi(1).eq.xpi(3) .and. xpi(5).eq.xpi(6) ) then
+	if ( xpi(2).eq.xpi(3) .and. xpi(4).eq.xpi(6) ) then
 	    if ( lwrite ) print *,'special case m1=m3,p5=p6'
 	    cs(2) = + cb0i(2)*DBLE(xpi(5))
 	    cs(3) = 0

--- a/src/ff/ffxd0.f
+++ b/src/ff/ffxd0.f
@@ -729,9 +729,9 @@ c
 	    print *,'cd0  :',cs*cfac
  1012	    format(g12.6,1x,g12.6,i4,2x,g12.6,1x,g12.6,i4)
  1013	    format(g12.6,1x,g12.6,i4,2x,g12.6,1x,g12.6,i4,2x,g12.6,1x,
-     +		g12.6,i4)
+     +        g12.6,i4)
  1004	    format(g12.6,1x,g12.6,2x,g12.6,1x,g12.6,2x,g12.6,1x,g12.6,
-     +		2x,g12.6,1x,g12.6)
+     +        2x,g12.6,1x,g12.6)
 	endif
 *  #] debug:
 *###] ffxd0e:

--- a/src/ff/ffxd0.f
+++ b/src/ff/ffxd0.f
@@ -729,9 +729,9 @@ c
 	    print *,'cd0  :',cs*cfac
  1012	    format(g12.6,1x,g12.6,i4,2x,g12.6,1x,g12.6,i4)
  1013	    format(g12.6,1x,g12.6,i4,2x,g12.6,1x,g12.6,i4,2x,g12.6,1x,
-     +        g12.6,i4)
+     +		g12.6,i4)
  1004	    format(g12.6,1x,g12.6,2x,g12.6,1x,g12.6,2x,g12.6,1x,g12.6,
-     +        2x,g12.6,1x,g12.6)
+     +		2x,g12.6,1x,g12.6)
 	endif
 *  #] debug:
 *###] ffxd0e:

--- a/src/ff/ffxd0p.f
+++ b/src/ff/ffxd0p.f
@@ -460,10 +460,10 @@
 	    else
 		if ( lcroot ) then
 		   call ffcxra(cs4(167),ipi12(23),xqi,qiDqj,sdel2,2,ier)
-		   call ffcxra(cs4(169),ipi12(25),xqi,qiDqj,sdel2,3,ier)
+*		   call ffcxra(cs4(169),ipi12(25),xqi,qiDqj,sdel2,3,ier)
 		else
 		   call ffxtra(cs4(167),ipi12(23),xqi,qiDqj,sdel2,2,ier)
-		   call ffxtra(cs4(169),ipi12(25),xqi,qiDqj,sdel2,3,ier)
+*		   call ffxtra(cs4(169),ipi12(25),xqi,qiDqj,sdel2,3,ier)
 *		   call ffxtro(cs4(167),ipi12(23),xqi,qiDqj,sdel2,2,ier)
 *		   call ffxtro(cs4(169),ipi12(25),xqi,qiDqj,sdel2,3,ier)
 		endif


### PR DESCRIPTION
* Copy the source contents of QCDLoop `v1.981`'s `QCDLoop-1.98/ff/*` to `src/ff/`, and rename files as needed so that the changes between them can be tracked with version control (e.g. rename `makefile` -> `Makefile`).
* Add QCDLoop's `v1.981` FF `Changelog` from 2020-06-04 which summarizes the changes.
* Do not add Keith Ellis's `ffinit_mine.f` though as it is unclear if this is even needed.